### PR TITLE
Rename repo to markdown-vue

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# markdown-it - vue
+# markdown-vue
 
 This is a simple proof of concept Vue app that renders some markdown [in a component](https://github.com/brianzelip/markdown-it-vue/blob/master/src/App.vue#L15-L18).
 
@@ -10,7 +10,8 @@ See [the demo](https://markdown-it-vue.netlify.com).
 
 - [Parcel](https://parceljs.org)
 - [Vue](https://vuejs.org)
-- [markdown-it](https://github.com/markdown-it/markdown-it)
+- [@vue/babel-preset-jsx](https://github.com/vuejs/jsx)
+- ~~[markdown-it](https://github.com/markdown-it/markdown-it)~~
 - [parcel-plugin-markdown-string](https://github.com/jaywcjlove/parcel-plugin-markdown-string)
 
 ## guiding ideas
@@ -28,7 +29,7 @@ The bio changes over time. As such, I'd like to refactor it out of the html and 
 
 Sure, the bio is just a string, and since I'm using Vue, why not just make a data property for this string? I could! But the string has a link in it, and I don't want to write html outside of html! Even if the string does not have a link in it, it's still nicer to maintain strings in markdown than html.
 
-This repo was born from [attempts at getting Gridsome to generate my static home page](https://github.com/brianzelip/zelip.me) from Vue components that render markdown content. However, Gridsome seems to only want to work with markdown files at page scale (file == page), not at the more granular data point scale (file == page *content*).
+This repo was born from [attempts at getting Gridsome to generate my static home page](https://github.com/brianzelip/zelip.me) from Vue components that render markdown content. However, Gridsome seems to only want to work with markdown files at page scale (file == page), not at the more granular data point scale (file == page _content_).
 
 ## Vue-related concerns with this approach
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # markdown-vue
 
-This is a simple proof of concept Vue app that renders some markdown [in a component](https://github.com/brianzelip/markdown-vue/blob/master/src/App.vue#L15-L18).
+This is a simple proof of concept Vue app that renders some markdown in a component.
 
 The aim of this project is to figure out a solution to import a markdown file into a Vue component to be rendered like any data or computed property.
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # markdown-vue
 
-This is a simple proof of concept Vue app that renders some markdown [in a component](https://github.com/brianzelip/markdown-it-vue/blob/master/src/App.vue#L15-L18).
+This is a simple proof of concept Vue app that renders some markdown [in a component](https://github.com/brianzelip/markdown-vue/blob/master/src/App.vue#L15-L18).
 
 The aim of this project is to figure out a solution to import a markdown file into a Vue component to be rendered like any data or computed property.
 
-See [the demo](https://markdown-it-vue.netlify.com).
+See [the demo](https://markdown-vue.netlify.com).
 
 ## starring
 

--- a/changelog.md
+++ b/changelog.md
@@ -46,12 +46,22 @@ Use `domPropsInnerHTML`, not `v-html` in jsx!
 
 via [stack overflow](https://stackoverflow.com/a/50002981/2145103) and [babel-plugin-transform-vue-jsx docs](https://github.com/vuejs/babel-plugin-transform-vue-jsx#difference-from-react-jsx)
 
-3. Render mdx
+3. Change repo name to markdown-vue
 
 - starting point: v1.1.1
 - ending point: v2.0.0
+- starting branch: rename-repo
+- steps:
+  - update gh repo settings
+  - update all link references to old URL in copy
+  - update all link references to old url in code
+  - update git configs all around
+
+4. Render mdx
+
+- starting point: v2.0.0
+- ending point: v2.1.0
 - starting branch: mdx
 - steps:
-  - **rename repo** to markdown-vue
   - get rid of markdown-it
   - implent mdx

--- a/changelog.md
+++ b/changelog.md
@@ -46,9 +46,9 @@ Use `domPropsInnerHTML`, not `v-html` in jsx!
 
 via [stack overflow](https://stackoverflow.com/a/50002981/2145103) and [babel-plugin-transform-vue-jsx docs](https://github.com/vuejs/babel-plugin-transform-vue-jsx#difference-from-react-jsx)
 
-1. Render mdx
+3. Render mdx
 
-- starting point: v1.1.0
+- starting point: v1.1.1
 - ending point: v2.0.0
 - starting branch: mdx
 - steps:

--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta http-equiv="X-UA-Compatible" content="ie=edge" />
-    <title>markdown-it vue sandbox</title>
+    <title>markdown vue sandbox</title>
   </head>
   <body>
     <div id="app"></div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "markdown-it-vue",
+  "name": "markdown-vue",
   "version": "1.1.1",
   "lockfileVersion": 1,
   "requires": true,

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "markdown-it-vue",
+  "name": "markdown-vue",
   "version": "1.1.1",
-  "description": "Sandbox for rendering markdown in vue templates using markdown-it.",
+  "description": "Sandbox for rendering markdown in vue templates.",
   "main": "index.html",
   "repository": {
     "url": "https://github.com/brianzelip/markdown-it-vue.git"

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Sandbox for rendering markdown in vue templates.",
   "main": "index.html",
   "repository": {
-    "url": "https://github.com/brianzelip/markdown-it-vue.git"
+    "url": "https://github.com/brianzelip/markdown-vue.git"
   },
   "scripts": {
     "start": "parcel index.html",


### PR DESCRIPTION
This PR:

- renames the repo to markdown-vue
- updates all references to the old scope, including readme, git configs, and more
- bumps the version to v2.0.0
- closes #3 